### PR TITLE
Don’t compile custom CSS files

### DIFF
--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -67,7 +67,11 @@ let paths = {
 	styles: {
 		cssCustomProperties: `${assetsDir}/css/src/custom-properties.css`,
 		cssCustomMedia: `${assetsDir}/css/src/custom-media.css`,
-		src: `${assetsDir}/css/src/**/*.css`,
+		src: [
+			`${assetsDir}/css/src/**/*.css`,
+			`!${assetsDir}/css/src/custom-media.css`,
+			`!${assetsDir}/css/src/custom-properties.css`,
+		],
 		sass: `${assetsDir}/css/src/**/*.scss`,
 		dest: `${assetsDir}/css/`
 	},


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
The CSS compile was compiling the CSS variable property and media files and creating unnecessary, empty files. This removes them from compilation.

Addresses issue #
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [ ] I want my code added to WP Rig.
